### PR TITLE
Correct mention regex

### DIFF
--- a/autolinklibrary/src/main/java/io/github/armcha/autolink/Regex.kt
+++ b/autolinklibrary/src/main/java/io/github/armcha/autolink/Regex.kt
@@ -17,5 +17,5 @@ internal val EMAIL_PATTERN: Pattern = Pattern.compile(
                 "\\." +
                 "[a-zA-Z0-9][a-zA-Z0-9\\-]{0,25}" +
                 ")+")
-internal val MENTION_PATTERN: Pattern = Pattern.compile("(?:^|\\s*|$|[.])@[\\p{L}0-9_]*")
+internal val MENTION_PATTERN: Pattern = Pattern.compile("(?:^|\\s*|$|[.])@([\\p{L}0-9_](.|))*([\p{L}0-9])$")
 internal val HASH_TAG_PATTERN: Pattern = Pattern.compile("#[^\\s!@#\$%^&*()=+./,\\[{\\]};:'\"?><]+")


### PR DESCRIPTION
![Screen Shot 2020-11-30 at 08 17 47](https://user-images.githubusercontent.com/16656689/100614731-947bb680-32e4-11eb-9504-2e8a1da83b03.png)

(when using regexr, replace all `\\` with `\` then select "PCRE" as engine (not JS))